### PR TITLE
Updated for tf .14 and Azure fixes/adds

### DIFF
--- a/Azure/instance.tf
+++ b/Azure/instance.tf
@@ -14,7 +14,7 @@ resource "azurerm_virtual_machine" "openvpn" {
   storage_image_reference {
     publisher = "Canonical"
     offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    sku       = "18.04-LTS"
     version   = "latest"
   }
 
@@ -93,10 +93,10 @@ resource "azurerm_virtual_machine" "openvpn" {
     }
   }
 
-  provisioner "local-exec" {
-    command = "rm -f ${var.client_config_path}/${var.client_config_name}.ovpn"
-    when    = destroy
-  }
+  #provisioner "local-exec" {
+  #  command = "rm -f ${var.client_config_path}/${var.client_config_name}.ovpn"
+  #  when    = destroy
+  #}
 }
 
 data "template_file" "deployment_shell_script" {

--- a/Azure/instance.tf
+++ b/Azure/instance.tf
@@ -3,7 +3,7 @@ resource "azurerm_virtual_machine" "openvpn" {
   location              = var.location
   resource_group_name   = azurerm_resource_group.rg.name
   network_interface_ids = [azurerm_network_interface.nic.id]
-  vm_size               = "Standard_A0"
+  vm_size               = "Standard_B2s"
 
   # Uncomment this line to delete the OS disk automatically when deleting the VM
   delete_os_disk_on_termination = true

--- a/Azure/main.tf
+++ b/Azure/main.tf
@@ -1,4 +1,5 @@
 provider "azurerm" {
+  features{}
 }
 
 resource "azurerm_resource_group" "rg" {
@@ -8,4 +9,21 @@ resource "azurerm_resource_group" "rg" {
 
 terraform {
   required_version = ">= 0.12"
+}
+
+/* # This somehow started erroring on me after it worked before, not sure why so not using this, but leaving it in as an alternate option
+# Grab current source internet ip to use for nsg
+data "http" "myextip" {
+url = "http://v4.ident.me"
+}
+*/
+
+# Grab current source internet ip to use for nsg
+data "http" "geoipdata" {
+  url = "http://www.geoplugin.net/json.gp"
+
+  # Optional request headers
+  request_headers = {
+    Accept = "application/json"
+  }
 }

--- a/Azure/outputs.tf
+++ b/Azure/outputs.tf
@@ -2,3 +2,14 @@ output "public_ip" {
   value = "The VPN Public IP Address: ${azurerm_public_ip.pubip.ip_address}"
 }
 
+output "public_dns" {
+  value = "The VPN Public DNS: ${azurerm_public_ip.pubip.fqdn}"
+}
+
+output "restrict_ssh" {
+  value = var.restrict_ssh == true ? "SSH access has been restricted to requests from IP ${(jsondecode(data.http.geoipdata.body)).geoplugin_request}" : "SSH Access has NOT been restricted and is open to the entire internet"
+}
+
+output "restrict_vpn" {
+  value = var.restrict_vpn == true ? "VPN access has been restricted to requests from IP ${(jsondecode(data.http.geoipdata.body)).geoplugin_request}" : "VPN Access has NOT been restricted and is open to the entire internet"
+}

--- a/Azure/userdata.sh
+++ b/Azure/userdata.sh
@@ -8,7 +8,7 @@ echo "Reset DNS settings ..."
 
 echo "supersede domain-name-servers 1.1.1.1, 9.9.9.9;" >> /etc/dhcp/dhclient.conf
 
-dhclient -r -v ${INTERFACE} && rm /var/lib/dhcp/dhclient.* ; dhclient -v ${INTERFACE}
+dhclient -r -v $${INTERFACE} && rm /var/lib/dhcp/dhclient.* ; dhclient -v $${INTERFACE}
 
 echo "Adding official OpenVPN Distro ..."
 
@@ -35,8 +35,8 @@ echo "# START OPENVPN RULES
 # NAT table rules
 *nat
 :POSTROUTING ACCEPT [0:0]
-# Allow traffic from OpenVPN client to ${INTERFACE}
--A POSTROUTING -s 192.168.53.0/28 -o ${INTERFACE} -j MASQUERADE
+# Allow traffic from OpenVPN client to $${INTERFACE}
+-A POSTROUTING -s 192.168.53.0/28 -o $${INTERFACE} -j MASQUERADE
 COMMIT
 # END OPENVPN RULES
 

--- a/Azure/variables.tf
+++ b/Azure/variables.tf
@@ -1,5 +1,5 @@
 variable "location" {
-  default = "Canada East"
+  default = "westus2"
 }
 
 variable "hostname" {
@@ -8,6 +8,20 @@ variable "hostname" {
 
 variable "admin_username" {
   default = "ubuntu"
+}
+
+# Variable to restrict SSH access by NSG ACL to internet IP of client running tf
+variable "restrict_ssh" {
+  description = "If set to true, restrict SSH by NSG ACL"
+  type        = bool
+  default     = true
+}
+
+# Variable to restrict VPN access by NSG ACL to internet IP of client running tf
+variable "restrict_vpn" {
+  description = "If set to true, restrict vpn by NSG ACL"
+  type        = bool
+  default     = true
 }
 
 variable "private_key_file" {

--- a/AzureMktPlace/README.md
+++ b/AzureMktPlace/README.md
@@ -1,0 +1,3 @@
+# TerraformOpenVPN/AzureMktPlace
+This section uses the openvpn published Azure Marketplace image as a base, instead of a default linux image. Additionally, it's configuration is pretty 'vanilla' per the openvpn initialization script and mostly aligns with the setup documentation found here https://openvpn.net/vpn-server-resources/microsoft-azure-byol-appliance-quick-start-guide/.
+In addition to variables set in 'variables.tf' configuration details are also handled by cloud init config 'cloud-init.txt' and 'openvpncfg.txt' which are passed to the instance at boot. Tf builds it all and cloud-init runs 'ovpn-init --batch' which applies a default config using the info passed via userdata from 'openvpncfg.txt'

--- a/AzureMktPlace/cloud-init.txt
+++ b/AzureMktPlace/cloud-init.txt
@@ -1,0 +1,18 @@
+#cloud-config
+# Install updates
+package_update: true
+package_upgrade: true
+runcmd:
+- ovpn-init --batch --host ${domain_name_label}
+users:
+- default
+- name: openvpn
+chpasswd:
+  list:
+    - ${ovpnadmin_username}:${ovpnadmin_password}
+  expire: False
+power_state:
+  delay: now
+  mode: reboot
+  message: Rebooting the OS
+  condition: if [ -e /var/run/reboot-required ]; then exit 0; else exit 1; fi

--- a/AzureMktPlace/instance.tf
+++ b/AzureMktPlace/instance.tf
@@ -1,0 +1,82 @@
+resource "azurerm_linux_virtual_machine" "openvpn" {
+  name                  = var.hostname
+  admin_username        = var.admin_username
+  location              = var.location
+  resource_group_name   = azurerm_resource_group.rg.name
+  network_interface_ids = [azurerm_network_interface.nic.id]
+  size                  = "Standard_B2s"
+  custom_data           = data.template_cloudinit_config.config.rendered
+
+  admin_ssh_key {
+    username   = var.admin_username
+    public_key = file(var.public_key_file)
+  }
+
+  plan {
+    publisher = "openvpn"
+    product   = "openvpnas"
+    name      = "access_server_byol"
+  }
+
+  source_image_reference {
+    publisher = "openvpn"
+    offer     = "openvpnas"
+    sku       = "access_server_byol"
+    version   = "latest"
+  }
+
+  #This would be the vanilla image, not using this
+  #source_image_reference {
+  #  publisher = "Canonical"
+  #  offer     = "UbuntuServer"
+  #  sku       = "18.04-LTS"
+  #  version   = "latest"
+  #}
+
+  os_disk {
+    name                 = "${var.hostname}_os"
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  connection {
+    type        = "ssh"
+    host        = azurerm_public_ip.pubip.ip_address
+    user        = var.admin_username
+    private_key = file(var.private_key_file)
+  }
+
+}
+
+data "template_file" "cloudconfig" {
+  template = file("cloud-init.txt")
+  vars = {
+    ovpnadmin_password = random_password.ovpnadmin_password.result
+    ovpnadmin_username = var.ovpnadmin_username
+    domain_name_label  = azurerm_public_ip.pubip.fqdn
+  }
+}
+
+data "template_file" "openvpnconfig" {
+  template = file("openvpncfg.txt")
+  vars = {
+    domain_name_label  = azurerm_public_ip.pubip.fqdn
+    ovpnadmin_username = var.ovpnadmin_username
+  }
+}
+
+data "template_cloudinit_config" "config" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/cloud-config"
+    content      = data.template_file.cloudconfig.rendered
+  }
+
+  part {
+    content_type = "text/plain"
+    content      = data.template_file.openvpnconfig.rendered
+  }
+
+}

--- a/AzureMktPlace/main.tf
+++ b/AzureMktPlace/main.tf
@@ -1,0 +1,40 @@
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "openvpn${random_string.dns-name.result}"
+  location = var.location
+}
+
+terraform {
+  required_version = ">= 0.12"
+}
+
+/* # This somehow started erroring on me after it worked before, not sure why so not using this, but leaving it in as an alternate option
+# Grab current source internet ip to use for nsg
+data "http" "myextip" {
+url = "http://v4.ident.me"
+}
+*/
+
+# Grab current source internet ip to use for nsg
+data "http" "geoipdata" {
+  url = "http://www.geoplugin.net/json.gp"
+
+  # Optional request headers
+  request_headers = {
+    Accept = "application/json"
+  }
+}
+
+# Generate random password for openvpnadmin
+resource "random_password" "ovpnadmin_password" {
+  length           = 16
+  min_upper        = 2
+  min_lower        = 2
+  min_special      = 2
+  number           = true
+  special          = true
+  override_special = "!@#$%&"
+}

--- a/AzureMktPlace/network.tf
+++ b/AzureMktPlace/network.tf
@@ -1,0 +1,121 @@
+resource "azurerm_virtual_network" "vnet" {
+  name                = "OpenVPNVNet"
+  resource_group_name = azurerm_resource_group.rg.name
+  address_space       = ["192.168.50.0/24"]
+  location            = var.location
+  dns_servers         = ["1.1.1.1", "9.9.9.9"]
+}
+
+resource "azurerm_subnet" "VPNSubnet" {
+  name                 = "VPNSubnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["192.168.50.16/28"]
+}
+
+resource "azurerm_network_security_group" "sg" {
+  name                = "sg-openvpn"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name                       = "PermitSSHInbound"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = var.restrict_ssh == true ? (jsondecode(data.http.geoipdata.body)).geoplugin_request : "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "PermitOpenVPNAdminInbound"
+    priority                   = 110
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "943"
+    source_address_prefix      = var.restrict_ssh == true ? (jsondecode(data.http.geoipdata.body)).geoplugin_request : "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "PermitOpen443Inbound"
+    priority                   = 120
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = var.restrict_vpn == true ? (jsondecode(data.http.geoipdata.body)).geoplugin_request : "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "PermitOpen1194Inbound"
+    priority                   = 130
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "1194"
+    source_address_prefix      = var.restrict_vpn == true ? (jsondecode(data.http.geoipdata.body)).geoplugin_request : "*"
+    destination_address_prefix = "*"
+  }
+
+}
+
+resource "random_string" "dns-name" {
+  length  = 4
+  upper   = false
+  lower   = true
+  number  = true
+  special = false
+}
+
+resource "azurerm_public_ip" "pubip" {
+  name                = "${var.hostname}-public"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.location
+  allocation_method   = "Static"
+  domain_name_label   = "openvpn${random_string.dns-name.result}"
+}
+
+resource "azurerm_network_interface" "nic" {
+  name                 = var.hostname
+  location             = var.location
+  resource_group_name  = azurerm_resource_group.rg.name
+  enable_ip_forwarding = true
+
+  ip_configuration {
+    name                          = var.hostname
+    subnet_id                     = azurerm_subnet.VPNSubnet.id
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = azurerm_public_ip.pubip.id
+  }
+}
+
+resource "azurerm_route_table" "ovpn_route_table" {
+  name                          = "ovpnroutetable"
+  location                      = var.location
+  resource_group_name           = azurerm_resource_group.rg.name
+  disable_bgp_route_propagation = false
+
+  route {
+    name                   = "ovpnroute1"
+    address_prefix         = "172.27.224.0/20"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = azurerm_network_interface.nic.private_ip_address
+  }
+
+  route {
+    name                   = "ovpnroute2"
+    address_prefix         = "172.27.240.0/20"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = azurerm_network_interface.nic.private_ip_address
+  }
+
+}

--- a/AzureMktPlace/openvpncfg.txt
+++ b/AzureMktPlace/openvpncfg.txt
@@ -1,0 +1,2 @@
+#public_hostname=${domain_name_label}
+admin_user=${ovpnadmin_username}

--- a/AzureMktPlace/outputs.tf
+++ b/AzureMktPlace/outputs.tf
@@ -1,0 +1,27 @@
+output "public_ip" {
+  value = "The VPN Public IP Address: ${azurerm_public_ip.pubip.ip_address}"
+}
+
+output "public_dns" {
+  value = "The VPN Public DNS: ${azurerm_public_ip.pubip.fqdn}"
+}
+
+output "restrict_ssh" {
+  value = var.restrict_ssh == true ? "SSH access has been restricted to requests from IP ${(jsondecode(data.http.geoipdata.body)).geoplugin_request}" : "SSH Access has NOT been restricted and is open to the entire internet"
+}
+
+output "restrict_vpn" {
+  value = var.restrict_vpn == true ? "VPN access has been restricted to requests from IP ${(jsondecode(data.http.geoipdata.body)).geoplugin_request}" : "VPN Access has NOT been restricted and is open to the entire internet"
+}
+
+output "admin_url" {
+  value = "The VPN admin console url is: https://${azurerm_public_ip.pubip.fqdn}:943/admin"
+}
+
+output "admin_info" {
+  value = "The VPN admin username is:${var.ovpnadmin_username} with password of:${random_password.ovpnadmin_password.result}"
+}
+
+output "be_patient" {
+  value = "Cloud-init will bootstrap and restart the machine if needed so the vm will take 1-10 mins to be ready"
+}

--- a/AzureMktPlace/variables.tf
+++ b/AzureMktPlace/variables.tf
@@ -1,0 +1,50 @@
+variable "location" {
+  default = "westus2"
+}
+
+variable "hostname" {
+  default = "openvpn"
+}
+
+variable "admin_username" {
+  default = "ubuntu"
+}
+
+variable "ovpnadmin_username" {
+  default = "openvpn"
+}
+
+# Variable to restrict SSH access by NSG ACL to internet IP of client running tf
+variable "restrict_ssh" {
+  description = "If set to true, restrict SSH by NSG ACL"
+  type        = bool
+  default     = true
+}
+
+# Variable to restrict VPN access by NSG ACL to internet IP of client running tf
+variable "restrict_vpn" {
+  description = "If set to true, restrict vpn by NSG ACL"
+  type        = bool
+  default     = true
+}
+
+variable "private_key_file" {
+  default = "../certs/ovpn"
+}
+
+variable "public_key_file" {
+  default = "../certs/ovpn.pub"
+}
+
+variable "client_config_path" {
+  default = "../client_configs"
+}
+
+#variable "client_config_name" {
+#  default = "azure-ovpn-client"
+#}
+
+#variable "cert_details" {
+#  default = "../cert_details"
+#}
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TerraformOpenVPN
-Terraform scripts to create a quick OpenVPN server in the cloud (AWS, Google (GCP), more to come). Can be trivially modified to work with other cloud providers.
+Terraform scripts to create a quick OpenVPN server in the cloud (AWS, Azure, Google (GCP), more to come). Can be trivially modified to work with other cloud providers.
 
 ## Steps for use
 
@@ -15,13 +15,14 @@ Terraform scripts to create a quick OpenVPN server in the cloud (AWS, Google (GC
 
 6. Edit your own `cert_details` (use `cert_details.sample` as template)
 7. In the cloud provider you're using, edit the region in `variables.tf` as needed (default is Canada).
-8. For GCP, be sure you've created a new project and noted it in `variables.tf`.
-9. cd to the cloud provider directory and perform a `terraform apply`.
-10. The new `.ovpn` file will be copied from new instance into `cert_details`. Open with your OpenVPN client.
+8. For Azure it will restrict SSH and VPN to your public ip by default, if otherwise needed set variables 'restrict_vpn' or 'restrict_ssh' in `variables.tf`.
+9. For GCP, be sure you've created a new project and noted it in `variables.tf`.
+10. cd to the cloud provider directory and perform a `terraform apply`.
+11. The new `.ovpn` file will be copied from new instance into `cert_details`. Open with your OpenVPN client.
 
 ## To Do
 
-- Flag for "only allow this IP to connect" to either SSH and/or OpenVPN.
+- (AWS/GCP) Flag for "only allow this IP to connect" to either SSH and/or OpenVPN.
 - Finish `fail2ban` configuration.
 - Better use of variables and file hierarchy to allow for a single variables file and one place to execute the `apply` command.
 - Enable this repository to be used as a module.


### PR DESCRIPTION
0 - BUG - commented out destroy-time provisioner for client ovpn file as not supported with tf .14 - this will leave that file behind when tf destroy is run
1 - updated azure connection block to include features{}
2 - renamed to 'allocation_method' on azurerm_public_ip updated value to "Static"
3 - updated syntax to 'address_prefixES' on azurerm_subnet and values to list of strings (1) in network.tf x 2
4 - Remove network_security_group_id from azurerm_network_interface in network.tf 
5 - updated userdata.sh script to not use ${var} and $${var} instead
6 - update ubuntu image sku to 18.04 - available in Azure US but not Azure Canada?
8 - set enable_ip_forwarding to true on azure nic config
9 - Added flags for restricting SSH and VPN to IP of host running tf
10 - Added Azure DNS name for external IP - openvpn + 4 char random
11 - Added outputs for ssh/vpn restrictions and azure dns name
12 - Updated readme.md

tested with tf 0.14.2 on 12 Dec 2020